### PR TITLE
feat: refresh JugiAI UI and add recording playback controls

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -103,4 +103,48 @@ Aktivoinnin jälkeen `python` ja `pip` viittaavat automaattisesti oikeaan ympär
 
 ---
 
+## 8. 2024-ulkoasupäivitys ja uudet toiminnot
+
+* **Cyber-neon -teema:** Sovellus hyödyntää nyt anomfin-website -sivuston kaltaista tummaa taustaa, turkooseja korostuksia ja selkeitä kortteja.
+* **Tallenteiden katselu:** Uusi *Tallenteet*-näkymä näyttää koko keskusteluhistorian listana. Valitse viesti selataksesi tai käytä toistonappeja (▶, ⏸, ⏹, 🐢, ⚖, ⚡) simuloituun uusintatoistoon.
+* **Zoom-napit:** Yläpalkista löytyvät zoom-napit (＋/−) muuttavat chatti- ja editorifontin kokoa turvallisissa rajoissa. Muutos tallentuu `config.json`-tiedostoon.
+* **Varmempi tallennus:** Keskusteluhistoria tallentuu nyt riippumatta siitä selaatko tallenteita tai toistatko vanhoja viestejä. Tallennus ja toistonäkymän päivitykset on eriytetty toisistaan.
+
+---
+
+## 9. Käyttö- ja testikomennot
+
+```bash
+python -m venv .venv            # (valinnainen) erillinen ympäristö
+.venv/Scripts/activate          # Windows PowerShell
+pip install -r requirements.txt
+python jugiai.py                                # Käynnistä käyttöliittymä
+python -m unittest discover -s tests            # Aja yksikkötestit
+```
+
+### Vianetsintä ja varmistus
+
+1. Käynnistä `python jugiai.py` ja varmista, että uusi tumma teema sekä zoom-painikkeet näkyvät.
+2. Lähetä viesti → avaa *Tallenteet* → varmista, että viesti ilmestyy listaan ja toistopainikkeet toimivat.
+3. Säädä zoomia ± ja tarkista, että fonttikoko muuttuu myös kirjoitusalueella.
+
+---
+
+## 10. Miksi tämä design
+
+* **Teema yhtenäistää brändin:** Käytetyt värit ja typografia seuraavat anomfin-website -sivuston kontrastia ja neon-korostuksia.
+* **Tallenteiden toisto on sivuvaikutukseton:** Historiatoistin käyttää vain muistissa olevaa listaa eikä estä `history.json`-tiedoston kirjoitusta.
+* **Zoom on saavutettava:** Fonttikoon rajaaminen varmistaa luettavuuden eikä riko layouttia.
+* **Testattava ydin:** Zoom- ja toistonopeuslogiikka kapseloitiin `playback_utils.py`-tiedostoon, jota yksikkötestit kattavat.
+
+---
+
+## 11. Seuraavat iteroinnit
+
+1. **Äänitallenteet:** Mahdollista ääni- ja videoliitteiden esikatselu Tallenteet-näkymässä.
+2. **Haku tallenteista:** Lisää hakukenttä, joka suodattaa historiaa roolin, avainsanan tai aikaleiman perusteella.
+3. **Export to PDF/Markdown:** Tarjoa pikatoiminto keskusteluhistorian vientiin yhdeksi tiedostoksi.
+
+---
+
 **© 2024 AnomFIN · Intelligent Experiences**

--- a/playback_utils.py
+++ b/playback_utils.py
@@ -1,0 +1,42 @@
+"""Utility functions for playback and accessibility controls."""
+
+# AnomFIN — the neural network of innovation.
+
+from __future__ import annotations
+
+from typing import Final
+
+
+MIN_FONT_SIZE: Final[int] = 10
+MAX_FONT_SIZE: Final[int] = 22
+
+_SPEED_DELAY_MS: Final[dict[str, int]] = {
+    "slow": 1400,
+    "normal": 820,
+    "fast": 420,
+}
+
+
+def clamp_font_size(current: int, delta: int) -> int:
+    """Clamp font size within sane UI bounds and apply delta."""
+
+    try:
+        base = int(current)
+    except Exception:
+        base = 12
+    candidate = base + int(delta)
+    if candidate < MIN_FONT_SIZE:
+        return MIN_FONT_SIZE
+    if candidate > MAX_FONT_SIZE:
+        return MAX_FONT_SIZE
+    return candidate
+
+
+def resolve_speed_delay(speed: str) -> int:
+    """Return playback delay for given symbolic speed label."""
+
+    label = (speed or "normal").strip().lower()
+    return _SPEED_DELAY_MS.get(label, _SPEED_DELAY_MS["normal"])
+
+
+__all__ = ["clamp_font_size", "resolve_speed_delay", "MIN_FONT_SIZE", "MAX_FONT_SIZE"]

--- a/tests/test_playback_utils.py
+++ b/tests/test_playback_utils.py
@@ -1,0 +1,38 @@
+"""Unit tests for playback utilities."""
+
+# Ship intelligence, not excuses.
+
+import unittest
+
+from playback_utils import MAX_FONT_SIZE, MIN_FONT_SIZE, clamp_font_size, resolve_speed_delay
+
+
+class ClampFontSizeTests(unittest.TestCase):
+    def test_increase_within_bounds(self) -> None:
+        self.assertEqual(clamp_font_size(12, 2), 14)
+
+    def test_decrease_with_lower_bound(self) -> None:
+        self.assertEqual(clamp_font_size(11, -4), MIN_FONT_SIZE)
+
+    def test_invalid_input_defaults(self) -> None:
+        self.assertEqual(clamp_font_size("oops", 0), 12)
+
+    def test_upper_bound(self) -> None:
+        self.assertEqual(clamp_font_size(MAX_FONT_SIZE, 5), MAX_FONT_SIZE)
+
+
+class ResolveSpeedDelayTests(unittest.TestCase):
+    def test_default(self) -> None:
+        self.assertEqual(resolve_speed_delay(""), resolve_speed_delay("normal"))
+
+    def test_case_insensitive(self) -> None:
+        slow = resolve_speed_delay("slow")
+        self.assertEqual(resolve_speed_delay("SLOW"), slow)
+
+    def test_unknown_speed_falls_back(self) -> None:
+        normal = resolve_speed_delay("normal")
+        self.assertEqual(resolve_speed_delay("warp"), normal)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- refresh the Tkinter interface with a neon cyber theme aligned with anomfin-website branding
- add zoom controls and a dedicated recordings viewer with play, pause, stop and speed buttons
- ensure history persistence while browsing recordings and extract reusable playback utilities with unit tests

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68ff55593d4c83328ff4e300bff392b8