### PR TITLE
Fix install_utf8 bootstrap error handling

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -18,6 +18,12 @@ Tämä asiakirja kokoaa yhteen kaikki vaiheet, joilla AnomAI/JugiAI puretaan, as
 
 Asennusohjelma käy läpi seuraavat vaiheet ja pitää ikkunan auki myös virhetilanteissa, jotta näet selkeät korjausohjeet:
 
+### UTF-8-käynnistin (`install_utf8.bat`)
+
+* **Turvallinen koodisivun vaihto.** `install_utf8.bat` tunnistaa konsolin nykyisen koodisivun, yrittää vaihtaa UTF-8:aan ja palauttaa alkuperäisen tilan, vaikka `install.bat` epäonnistuisi.
+* **Rakenteinen lokitus.** Kaikki ilmoitukset tulostuvat JSON-muodossa (`{"component":"install_utf8", ...}`), joten ne on helppo ohjata lokityökaluun tai liittää tukipyyntöön.
+* **Virhesieto.** Jos koodisivun vaihto tai `install.bat`-haku epäonnistuu, skripti raportoi tilanteen, pitää prosessin käynnissä ja antaa yksiselitteiset jatko-ohjeet.
+
 1. **Käynnistä asennus** kaksoisklikkaamalla `install.bat`. Konsolin koodisivu vaihtuu automaattisesti UTF-8-muotoon, joten ääkköset näkyvät oikein.
 2. **Pythonin tunnistus ja tarkistus.** Skripti etsii asennetun Pythonin (`py -3`, `python`, `python3`) ja varmistaa, että käytössä on vähintään 64-bittinen Python 3.10. Halutessasi voit syöttää oman polun.
 3. **Virtuaaliympäristö `.venv`.** Projektiin luodaan automaattisesti `.venv`-kansio. Jos luonti epäonnistuu, jatketaan suoraan järjestelmän Pythonilla, mutta suosittelemme käyttämään virtuaaliympäristöä.
@@ -121,6 +127,7 @@ python -m venv .venv            # (valinnainen) erillinen ympäristö
 pip install -r requirements.txt
 python jugiai.py                                # Käynnistä käyttöliittymä
 python -m unittest discover -s tests            # Aja yksikkötestit
+python -m unittest tests.test_install_utf8_script  # Varmista asennuskääreen eheys
 ```
 
 ### Vianetsintä ja varmistus
@@ -128,6 +135,7 @@ python -m unittest discover -s tests            # Aja yksikkötestit
 1. Käynnistä `python jugiai.py` ja varmista, että uusi tumma teema sekä zoom-painikkeet näkyvät.
 2. Lähetä viesti → avaa *Tallenteet* → varmista, että viesti ilmestyy listaan ja toistopainikkeet toimivat.
 3. Säädä zoomia ± ja tarkista, että fonttikoko muuttuu myös kirjoitusalueella.
+4. Aja `install_utf8.bat` → varmista, että lokirivit ovat JSON-muotoisia ja että koodisivu palautuu, kun ikkuna suljetaan.
 
 ---
 
@@ -137,6 +145,7 @@ python -m unittest discover -s tests            # Aja yksikkötestit
 * **Tallenteiden toisto on sivuvaikutukseton:** Historiatoistin käyttää vain muistissa olevaa listaa eikä estä `history.json`-tiedoston kirjoitusta.
 * **Zoom on saavutettava:** Fonttikoon rajaaminen varmistaa luettavuuden eikä riko layouttia.
 * **Testattava ydin:** Zoom- ja toistonopeuslogiikka kapseloitiin `playback_utils.py`-tiedostoon, jota yksikkötestit kattavat.
+* **UTF-8-kääre on idempotentti:** `install_utf8.bat` palauttaa alkuperäisen koodisivun ja raportoi JSON-lokeilla, joten se on turvallista ajaa myös skriptien sisältä.
 
 ---
 

--- a/install_utf8.bat
+++ b/install_utf8.bat
@@ -1,4 +1,102 @@
 @echo off
-:: Switch to UTF-8 code page and delegate to install.bat
-chcp 65001 >nul
-call "%~dp0install.bat"
+:: Windows-native AI. Zero friction, full acceleration.
+setlocal enabledelayedexpansion
+
+set "COMPONENT=install_utf8"
+set "EXIT_CODE=0"
+set "SWITCHED_UTF8=0"
+set "INSTALL_SCRIPT=%~dp0install.bat"
+set "ORIG_CP="
+
+call :capture_codepage
+if defined ORIG_CP (
+  call :log INFO "Detected active code page !ORIG_CP!."
+) else (
+  call :log WARN "Unable to detect active code page before switching."
+)
+
+call :switch_to_utf8
+call :invoke_install
+call :restore_codepage
+
+if not "!EXIT_CODE!"=="0" (
+  call :log ERROR "install_utf8 finished with exit code !EXIT_CODE!."
+) else (
+  call :log INFO "install_utf8 completed successfully."
+)
+
+endlocal & exit /b !EXIT_CODE!
+
+goto :eof
+
+:capture_codepage
+for /f "tokens=2 delims=:" %%C in ('chcp ^| find ":"') do (
+  for /f "tokens=1 delims= " %%D in ("%%C") do set "ORIG_CP=%%D"
+)
+if defined ORIG_CP (
+  set "ORIG_CP=!ORIG_CP: =!"
+)
+exit /b 0
+
+:switch_to_utf8
+if "!ORIG_CP!"=="65001" (
+  call :log INFO "Console already using UTF-8 code page."
+  goto :eof
+)
+chcp 65001 >nul 2>&1
+if errorlevel 1 (
+  call :log WARN "Failed to switch console to UTF-8. Continuing with code page !ORIG_CP!"
+  goto :eof
+)
+set "SWITCHED_UTF8=1"
+call :log INFO "Console code page switched to 65001 (UTF-8)."
+goto :eof
+
+:invoke_install
+if not exist "!INSTALL_SCRIPT!" (
+  call :log ERROR "Missing install.bat at !INSTALL_SCRIPT!."
+  set "EXIT_CODE=1"
+  goto :eof
+)
+call :log INFO "Delegating to install.bat with UTF-8 environment."
+call "!INSTALL_SCRIPT!"
+set "EXIT_CODE=!errorlevel!"
+if not "!EXIT_CODE!"=="0" (
+  call :log ERROR "install.bat exited with code !EXIT_CODE!."
+) else (
+  call :log INFO "install.bat completed without errors."
+)
+goto :eof
+
+:restore_codepage
+if not defined ORIG_CP goto :eof
+if "!SWITCHED_UTF8!"=="0" goto :eof
+if "!ORIG_CP!"=="" goto :eof
+if "!ORIG_CP!"=="65001" goto :eof
+chcp !ORIG_CP! >nul 2>&1
+if errorlevel 1 (
+  call :log WARN "Failed to restore original code page !ORIG_CP!. Run 'chcp !ORIG_CP!' manually if needed."
+) else (
+  call :log INFO "Restored original code page !ORIG_CP!."
+)
+goto :eof
+
+:log
+setlocal enabledelayedexpansion
+set "LEVEL=%~1"
+shift /1
+set "MESSAGE="
+:log_args
+if "%~1"=="" goto log_emit
+if defined MESSAGE (
+  set "MESSAGE=!MESSAGE! %~1"
+) else (
+  set "MESSAGE=%~1"
+)
+shift /1
+goto log_args
+:log_emit
+if not defined MESSAGE set "MESSAGE="
+set "MESSAGE=!MESSAGE:"=""!"
+echo {"component":"!COMPONENT!","level":"!LEVEL!","message":"!MESSAGE!"}
+endlocal & goto :eof

--- a/tests/test_install_utf8_script.py
+++ b/tests/test_install_utf8_script.py
@@ -1,0 +1,29 @@
+"""Tests for the install_utf8.bat wrapper."""
+# Ship intelligence, not excuses.
+
+import pathlib
+import unittest
+
+
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPT_PATH = PROJECT_ROOT / "install_utf8.bat"
+
+
+class InstallUtf8ScriptTests(unittest.TestCase):
+    def test_script_is_ascii_without_bom(self) -> None:
+        raw = SCRIPT_PATH.read_bytes()
+        self.assertFalse(raw.startswith(b"\xef\xbb\xbf"), "Script must not include UTF-8 BOM")
+        # Ensure ASCII-only content for stable Windows decoding without git churn.
+        raw.decode("ascii")
+
+    def test_script_contains_expected_guards(self) -> None:
+        content = SCRIPT_PATH.read_text(encoding="utf-8")
+        self.assertIn("COMPONENT=install_utf8", content)
+        self.assertIn("chcp 65001", content)
+        self.assertIn(":restore_codepage", content)
+        self.assertIn(":invoke_install", content)
+        self.assertIn('{"component":"!COMPONENT!","level":"!LEVEL!","message":"!MESSAGE!"}', content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- harden install_utf8.bat with code-page detection, JSON logging, and restore safeguards
- add regression tests ensuring the UTF-8 bootstrap stays ASCII and retains critical guards
- document the UTF-8 launcher workflow and verification steps in README

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_6906e5b30eac8332a22338d291172187